### PR TITLE
fix: disable tickCramming for bees

### DIFF
--- a/src/main/java/io/ib67/sfcraft/mixin/server/optimize/LivingEntityMixin.java
+++ b/src/main/java/io/ib67/sfcraft/mixin/server/optimize/LivingEntityMixin.java
@@ -1,0 +1,24 @@
+package io.ib67.sfcraft.mixin.server.optimize;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.passive.BeeEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin {
+    @Inject(method = "tickCramming", at=@At("HEAD"), cancellable = true)
+    private void sf$disableBeeCramming(CallbackInfo ci) {
+        if($this() instanceof BeeEntity) {
+            ci.cancel();
+        }
+    }
+
+    @Unique
+    private LivingEntity $this(){
+        return (LivingEntity) (Object) this;
+    }
+}

--- a/src/main/resources/sfcraft.mixins.json
+++ b/src/main/resources/sfcraft.mixins.json
@@ -32,7 +32,8 @@
     "server.subserver.PlayerManagerMixin",
     "server.subserver.PlayerSaveHandlerMixin",
     "server.subserver.ServerPlayerEntityMixin",
-    "server.subserver.PlayerListS2CPacket$EntryMixin"
+    "server.subserver.PlayerListS2CPacket$EntryMixin",
+    "server.optimize.LivingEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This patch applies to bees and non-player entities. For player interactions, there are no differences.

TPS: 9 -> 20, on server bee farm.
![image](https://github.com/user-attachments/assets/bc9051e8-f9ad-4e4c-9162-48cb3b854f83)
